### PR TITLE
Remove cf_app_discovery from the Prometheus box.

### DIFF
--- a/terraform/modules/prometheus/cloud.conf
+++ b/terraform/modules/prometheus/cloud.conf
@@ -40,7 +40,7 @@ users:
 
 package_update: true
 package_upgrade: true
-packages: ['chrony', 'nginx', 'ruby', 'python-pip']
+packages: ['chrony', 'nginx']
 
 mounts:
   - [ /dev/xvdh1, /mnt, auto]
@@ -103,16 +103,6 @@ write_files:
     path: /etc/nginx/sites-available/default
     permissions: 0644
   - owner: root:root
-    path: /etc/cron.d/sync_prometheus_discovery
-    content: |
-      PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-      */5 * * * * root cd /opt/cf_app_discovery/deploy && ./cf_app_discovery
-  - owner: root:root
-    path: /etc/cron.d/sync_prometheus_discovery_reboot
-    content: |
-      PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-      @reboot root cd /opt/cf_app_discovery/deploy && ./cf_app_discovery
-  - owner: root:root
     path: /etc/cron.d/lets_encrypt_renewal
     content: |
       PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
@@ -148,14 +138,6 @@ runcmd:
   - [ service, sshd, restart ]
   - [ bash, -c, "echo 'server 169.254.169.123 prefer iburst' >> /etc/chrony/chrony.conf" ] # Configure Amazon Time Sync
   - [ service, chrony, restart ]
-  - [ pip, install, --upgrade, pip ]
-  - [ pip, install, awscli, --upgrade, --user ]
-  - [ ln, -s, "/root/.local/bin/aws", /usr/local/bin/aws ]
-  - [ gem, install, bundler ]
-  - [ wget, -q, "https://github.com/alphagov/cf_app_discovery/archive/1.0.0.zip", -P, /tmp ]
-  - [ unzip, -d, /tmp, /tmp/1.0.0.zip ]
-  - [ mv, /tmp/cf_app_discovery-1.0.0, /opt/cf_app_discovery ]
-  - [ bash, -c, "cd /opt/cf_app_discovery && bundle --without development" ]
   - [ mkdir, /opt/prometheus ] # Extracted prometheus tarball
   - [ mkdir, /etc/prometheus/targets ] # Prometheus target configurations
   - [ wget, -q, "https://github.com/prometheus/prometheus/releases/download/v${prometheus_version}/prometheus-${prometheus_version}.linux-amd64.tar.gz", -P, /tmp ]


### PR DESCRIPTION
Installation, configuration and execution steps for the application
cf_app_discovery have been removed from the cloud-init script.