### PR TITLE
Alert manager base deployment & new ssh-key prometheus

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -23,6 +23,21 @@ module "prometheus" {
 }
 
 
+module "alertmanager" {
+  source             = "modules/alertmanager"
+
+  ami_id                = "${data.aws_ami.ubuntu.id}"
+  lets_encrypt_email    = "reliability-engineering-tools-team@digital.cabinet-office.gov.uk"
+  route53resource       = "${module.prometheus.route53resource}"
+  prom_subnet_id        = "${module.prometheus.prom_subnet_id}"
+  prom_security_groups  = "${module.prometheus.prom_security_groups}"
+  real_certificate      = "${var.real_certificate}"
+  domain_name           = "alerts.gds-reliability.engineering"
+  logstash_endpoint     = "47c3212e-794a-4be1-af7c-2eac93519b0a-ls.logit.io"
+  logstash_port         = 18210
+}
+
+
 resource "aws_ebs_volume" "promethues-disk" {
     availability_zone = "eu-west-1b"
     size = "500"

--- a/terraform/modules/alertmanager/cloud.conf
+++ b/terraform/modules/alertmanager/cloud.conf
@@ -1,6 +1,6 @@
 #cloud-config
 users:
-  - name: prometheus
+  - name: alertmanager
     system: true
 
   - name: davidking
@@ -40,87 +40,28 @@ users:
 
 package_update: true
 package_upgrade: true
-packages: ['chrony', 'nginx', 'ruby', 'python-pip']
-
-mounts:
-  - [ /dev/xvdh1, /mnt, auto]
+packages: ['chrony', 'python-pip']
 
 write_files:
   - content: |
       global:
-        scrape_interval: 15s
-      scrape_configs:
-        - job_name: prometheus
-          scrape_interval: 5s
-          static_configs:
-            - targets: ['localhost:9090']
-        - job_name: paas-targets
-          scheme: http
-          proxy_url: 'http://localhost:8080'
-          file_sd_configs:
-            - files: ['/etc/prometheus/targets/*.json']
-              refresh_interval: 30s
     owner: root:root
-    path: /etc/prometheus/prometheus.yml
+    path: /etc/alertmanager/alertmanager.yml
     permissions: 0644
   - content: |
       [Unit]
-      Description=Prometheus
+      Description=alertmanager
 
       [Service]
-      User=prometheus
-      ExecStart=/opt/prometheus/prometheus --config.file="/etc/prometheus/prometheus.yml" --storage.tsdb.path="/mnt/prometheus"
-      WorkingDirectory=/opt/prometheus
+      User=alertmanager
+      ExecStart=/opt/alertmanager/alertmanager --web.listen-address=":80" --config.file="/etc/alertmanager/alertmanager.yaml"
+      WorkingDirectory=/opt/alertmanager
 
       [Install]
       WantedBy = multi-user.target
     owner: root:root
-    path: /etc/systemd/system/prometheus.service
+    path: /etc/systemd/system/alertmanager.service
     permissions: 0644
-  - content: |
-      server {
-        listen 80 default_server;
-        server_name ${domain_name};
-        auth_basic "Prometheus";
-        auth_basic_user_file /etc/nginx/.htpasswd;
-
-        location / {
-          proxy_pass  http://localhost:9090;
-        }
-      }
-      server {
-        listen 8080;
-        resolver 10.0.0.2;
-
-        location / {
-          proxy_pass https://$host$uri;
-          proxy_ssl_server_name on;
-          proxy_set_header X-CF-APP-INSTANCE $arg_cf_app_guid:$arg_cf_app_instance_index;
-          proxy_set_header Authorization "Bearer $arg_cf_app_guid";
-        }
-      }
-    owner: root:root
-    path: /etc/nginx/sites-available/default
-    permissions: 0644
-  - owner: root:root
-    path: /etc/cron.d/sync_prometheus_discovery
-    content: |
-      PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-      */5 * * * * root cd /opt/cf_app_discovery/deploy && ./cf_app_discovery
-  - owner: root:root
-    path: /etc/cron.d/sync_prometheus_discovery_reboot
-    content: |
-      PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-      @reboot root cd /opt/cf_app_discovery/deploy && ./cf_app_discovery
-  - owner: root:root
-    path: /etc/cron.d/lets_encrypt_renewal
-    content: |
-      PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-      * 7,19 * * * root certbot renew --post-hook 'service nginx reload'
-  - owner: root:root
-    path: /etc/nginx/.htpasswd
-    permissions: 0444
-    content: "grafana:$apr1$LDmrTU1C$i1TWO7EiXgmVVOm3xkdpr0"
   - owner: root:root
     path: /etc/filebeat/filebeat.yml
     permissions: 0444
@@ -151,24 +92,17 @@ runcmd:
   - [ pip, install, --upgrade, pip ]
   - [ pip, install, awscli, --upgrade, --user ]
   - [ ln, -s, "/root/.local/bin/aws", /usr/local/bin/aws ]
-  - [ gem, install, bundler ]
-  - [ wget, -q, "https://github.com/alphagov/cf_app_discovery/archive/1.0.0.zip", -P, /tmp ]
-  - [ unzip, -d, /tmp, /tmp/1.0.0.zip ]
-  - [ mv, /tmp/cf_app_discovery-1.0.0, /opt/cf_app_discovery ]
-  - [ bash, -c, "cd /opt/cf_app_discovery && bundle --without development" ]
-  - [ mkdir, /opt/prometheus ] # Extracted prometheus tarball
-  - [ mkdir, /etc/prometheus/targets ] # Prometheus target configurations
-  - [ wget, -q, "https://github.com/prometheus/prometheus/releases/download/v${prometheus_version}/prometheus-${prometheus_version}.linux-amd64.tar.gz", -P, /tmp ]
-  - [ tar, xzvf, /tmp/prometheus-${prometheus_version}.linux-amd64.tar.gz, --strip-components=1, -C, /opt/prometheus ]
-  - [ mkdir, -p, /mnt/prometheus ]
-  - [ chown, -R, "prometheus:prometheus", /mnt/prometheus]
-  - [ chown, -R, "prometheus:prometheus", /opt/prometheus ]
-  - [ systemctl, enable, --now, prometheus.service ] # Start Prometheus
+  - [ mkdir, /opt/alertmanager ] 
+  - [ chown, -R, "alertmanager:alertmanager", /opt/prometheus ]
+  - [ systemctl, enable, --now, alertmanager.service ] 
   - [ add-apt-repository, "ppa:certbot/certbot", -y ]
+  - [ wget, -q, "https://github.com/prometheus/alertmanager/releases/download/v${alertmanager_version}/alertmanager-${alertmanager_version}.linux-amd64.tar.gz", -P, /tmp ]
+  - [ tar, xzvf, /tmp/alertmanager-${alertmanager_version}.linux-amd64.tar.gz, --strip-components=1, -C, /opt/alertmanager ]
+  - [ cp, /opt/alertmanager/simple.yml, /etc/alertmanager/alertmanager.yaml]
   - [ bash, -c, "echo 'deb https://artifacts.elastic.co/packages/6.x/apt stable main' >> /etc/apt/sources.list.d/elastic-6.x.list" ]
   - [ bash, -c, "wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add -" ]
   - [ apt-get, update ]
   - 'apt-get install -o Dpkg::Options::="--force-confold" filebeat python-certbot-nginx -y'
-  - [ certbot, ${real_certificate == "yes" ? "" : "--staging"}, -d, ${domain_name}, -m, ${lets_encrypt_email}, --authenticator, standalone, --installer, nginx, --pre-hook, "nginx -s stop", --post-hook, "nginx", --agree-tos, -n, --redirect ]
+  #- [ certbot, ${real_certificate == "yes" ? "" : "--staging"}, -d, ${domain_name}, -m, ${lets_encrypt_email}, --authenticator, standalone, --installer, nginx, --pre-hook, "nginx -s stop", --post-hook, "nginx", --agree-tos, -n, --redirect ]
   - [ systemctl, enable, filebeat ]
   - [ reboot ]

--- a/terraform/modules/alertmanager/main.tf
+++ b/terraform/modules/alertmanager/main.tf
@@ -1,0 +1,56 @@
+terraform {
+  required_version = ">= 0.11.2"
+}
+
+resource "aws_instance" "alertmanager" {
+  ami                    = "${var.ami_id}"
+  instance_type          = "t2.micro"
+  subnet_id              = "${var.prom_subnet_id}"
+  user_data              = "${data.template_file.user_data_script.rendered}"
+  vpc_security_group_ids = ["${var.prom_security_groups}"]
+
+  tags {
+    Name = "alertmanager"
+  }
+}
+
+
+#resource "aws_volume_attachment" "attach-prometheus-disk" {
+#  device_name = "${var.device_mount_path}"
+#  volume_id   = "${var.volume_to_attach}"
+#  instance_id = "${aws_instance.prometheus.id}"
+#  skip_destroy = true
+#}
+
+data "template_file" "user_data_script" {
+  template = "${file("${path.module}/cloud.conf")}"
+
+  vars {
+    alertmanager_version = "${var.alertmanager_version}"
+    domain_name        = "${var.domain_name}"
+    lets_encrypt_email = "${var.lets_encrypt_email}"
+    real_certificate   = "${var.real_certificate=="yes" ? "-v" : "--staging"}"
+    logstash_endpoint  = "${var.logstash_endpoint}"
+    logstash_port      = "${var.logstash_port}"
+  }
+}
+
+
+resource "aws_eip" "eip_alertmanager" {
+  vpc = true
+}
+
+resource "aws_eip_association" "eip_assoc" {
+  instance_id   = "${aws_instance.alertmanager.id}"
+  allocation_id = "${aws_eip.eip_alertmanager.id}"
+}
+
+
+resource "aws_route53_record" "alertmanager_www" {
+  zone_id = "${var.route53resource}"
+  name    = "alerts.gds-reliability.engineering"
+  type    = "A"
+  ttl     = "3600"
+  records = ["${aws_eip.eip_alertmanager.public_ip}"]
+}
+

--- a/terraform/modules/alertmanager/variables.tf
+++ b/terraform/modules/alertmanager/variables.tf
@@ -1,0 +1,62 @@
+# See https://sites.google.com/a/digital.cabinet-office.gov.uk/gds-internal-it/news/aviationhouse-sourceipaddresses for details.
+variable "cidr_admin_whitelist" {
+  description = "CIDR ranges permitted to communicate with administrative endpoints"
+  type        = "list"
+  default     = [
+    "213.86.153.212/32",
+    "213.86.153.213/32",
+    "213.86.153.214/32",
+    "213.86.153.235/32",
+    "213.86.153.236/32",
+    "213.86.153.237/32",
+    "85.133.67.244/32"
+  ]
+}
+
+variable "ami_id" {
+}
+
+variable "alertmanager_version" {
+  description = "alertmanager version to install in the machine"
+  default     = "0.14.0"
+}
+
+variable "device_mount_path" {
+  description = "The path to mount the promethus disk"
+  default = "/dev/sdh"
+}
+
+
+variable "domain_name" {
+  description = "Domain to serve Prometheus from and register for a TLS certificate"
+}
+
+variable "route53resource" {
+  description = "This is the default route53 resource created b prometheus"
+}
+
+variable "prom_subnet_id" {
+  description = "This is the default route53 resource created b prometheus"
+}
+
+
+variable "prom_security_groups" {
+  type = "list"
+  description = "This is the default route53 resource created b prometheus"
+}
+
+variable "lets_encrypt_email" {
+  description = "Email to register with Let's Encrypt CA"
+}
+
+variable "real_certificate" {
+  description = "Issue a real TLS certificate (yes/no)"
+}
+
+variable "logstash_endpoint" {
+  description = "Endpoint to send logs to for logstash"
+}
+
+variable "logstash_port" {
+  description = "Port of logstash endpoint"
+}

--- a/terraform/modules/prometheus/output.tf
+++ b/terraform/modules/prometheus/output.tf
@@ -5,3 +5,20 @@ output "data" {
 output "public_dns" {
   value = "${aws_instance.prometheus.public_dns}"
 }
+
+output "route53resource" {
+  value = "${aws_route53_zone.main.zone_id}"
+}
+
+output "prom_security_groups" {
+  value = [
+        "${aws_security_group.ssh_from_gds.id}",
+        "${aws_security_group.http_outbound.id}",
+        "${aws_security_group.external_http_traffic.id}",
+        "${aws_security_group.logstash_outbound.id}",
+      ]
+}
+
+output "prom_subnet_id" {
+  value = "${aws_subnet.main.id}"
+}


### PR DESCRIPTION
Added base alert manager. This inherits resources provided by prometheus module. It has the same key & cloud.conf is the instance provisioner. 

We need to verify config now & ensure the expected state of the system. The only other thing is creating a config & process for showing alerting in effect.