### PR TITLE
Skip authentication for /status to allow pinging.

### DIFF
--- a/terraform/modules/prometheus/cloud.conf
+++ b/terraform/modules/prometheus/cloud.conf
@@ -227,6 +227,10 @@ write_files:
         location / {
           proxy_pass  http://localhost:9090;
         }
+        location /status {
+          auth_basic off;
+          proxy_pass http://localhost:9090/status;
+        }
       }
       server {
         listen 8080;


### PR DESCRIPTION
Prometheus is entirely behind basic auth, which means an external uptime
monitoring service like Pingdom/Statuscake couldn't check it. This
removes the auth for a single readonly page so that we don't have to
give credentials to an external service.